### PR TITLE
feat: 영화 평점의 표시 및 평점별 폰트 컬러 변경

### DIFF
--- a/src/components/Movies/index.js
+++ b/src/components/Movies/index.js
@@ -19,7 +19,7 @@ export default function Movies() {
       <div key={item.id}>
         <a className="movieTitle" href={item.url}>
           {item.title} ({item.year})
-          <div className={rank}>평점 : {item.rating || '(평점없음)'} / 10 </div>
+          <div className={rank}>평점 : {item.rating || "(평점없음)"} / 10</div>
         </a>
       </div>
     )

--- a/src/components/Movies/index.js
+++ b/src/components/Movies/index.js
@@ -13,10 +13,13 @@ export default function Movies() {
   }, [])
 
   const render = movies.map((item) => {
+    const rank = item.rating >= 9 ? 'good' : item.rating >= 7 ? 'soso' : 'bad'
+
     return (
       <div key={item.id}>
         <a className="movieTitle" href={item.url}>
           {item.title} ({item.year})
+          <div className={rank}>평점 : {item.rating || '(평점없음)'} / 10 </div>
         </a>
       </div>
     )


### PR DESCRIPTION
#### 개요 
영화 평점의 표시 및 평점별 폰트 컬러 변경

#### 테스트 
1. title 옆에 (8/10)의 형태로 표시

2. 평점의 폰트 컬러를 변경
9점 이상은 blue
7점 이상은 orange
7점 미만은 red
API 주소에서 ?sort_by=rating 쿼리스트링을 제거해서 테스트할 것

3. 영화 평점 0일 때의 "(평점 없음)"으로 표시